### PR TITLE
v2.1.2 Add jquery as peerDependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.1.2 (2020-12-07)
+
+### Development
+
+- Add jquery@^1.12.0 as peerDependency. (Although skeletabs works with jquery versions down to v1.7.0, these versions are not compatible with the latest node.js engine during development.)
+
 ## 2.1.1 (2020-11-10)
 
 ### Functionality

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skeletabs",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Basic, accessible, responsive and freely restyleable tabs.",
   "main": "src/index.js",
   "scripts": {
@@ -53,6 +53,9 @@
   },
   "dependencies": {
     "lodash.debounce": "^4.0.8"
+  },
+  "peerDependencies": {
+    "jquery": "^1.12.0"
   },
   "babel": {
     "presets": [

--- a/test/index.html
+++ b/test/index.html
@@ -216,20 +216,9 @@
         <button id="remove" class="control-button">Remove</button>
       </div>
     </div>
-    <!-- jQuery v1.7.0 -->
-    <script
-      src="https://code.jquery.com/jquery-1.7.min.js"
-      integrity="sha256-/05Jde9AMAT4/o5ZAI23rUf1SxDYTHLrkOco0eyRV84="
-      crossorigin="anonymous"
-    ></script>
-    <!-- jQuery v3.5.1 -->
-    <!-- <script
-      src="https://code.jquery.com/jquery-3.5.1.min.js"
-      integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0="
-      crossorigin="anonymous"
-    ></script> -->
     <!-- provided by webpack -->
     <script src="../skeletabs.js"></script>
+    <!-- test script -->
     <script src="./index.js"></script>
   </body>
 </html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,6 @@
 /* eslint-disable global-require */
+// Expose webpack's built-in modules
+const webpack = require('webpack');
 // Node.js path helper
 const path = require('path');
 // CSS extractor
@@ -105,7 +107,12 @@ if (isDevMode()) {
       filename: `${pkg.name}.js`,
       path: path.resolve(__dirname, 'test'),
     },
-    plugins: [],
+    plugins: [
+      new webpack.ProvidePlugin({
+        $: 'jquery',
+        jQuery: 'jquery',
+      }),
+    ],
     optimization: {},
     devServer: {
       open: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3837,6 +3837,11 @@ isobject@^3.0.0, isobject@^3.0.1:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
+jquery@^1.12.0:
+  version "1.12.4"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-1.12.4.tgz#01e1dfba290fe73deba77ceeacb0f9ba2fec9e0c"
+  integrity sha1-AeHfuikP5z3rp3zurLD5ui/sngw=
+
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
- Add jquery@^1.12.0 as peerDependency. (Although skeletabs works with jquery versions down to v1.7.0, these versions are not compatible with the latest node.js engine during development.)